### PR TITLE
fix to clearing the $this->fake_data

### DIFF
--- a/src/TwigFakerExtension.php
+++ b/src/TwigFakerExtension.php
@@ -40,6 +40,7 @@ class TwigFakerExtension extends \Twig_Extension {
      */
     public function fakerData($type, $count = 1, $cache_key = null)
     {
+        $this->fake_data = [];
         $this->getFromCache($type, $count, $cache_key);
         if ($this->fake_data) return $this->fake_data;
 
@@ -89,7 +90,6 @@ class TwigFakerExtension extends \Twig_Extension {
     private function createNewFakeData($type, $count)
     {
         $faker = Factory::create();
-        $this->fake_data = [];
 
         for ($i = 0; $i < $count; $i++)
         {


### PR DESCRIPTION
with the cache introduced, now when you don't use cache, it will still return old data, 
since `$this->fake_data` is not being cleard so the `if($this->fake_data)` resolves to true.

I have moved `$this->fake_data = []` from `createNewFakeData` to `fakerData`
